### PR TITLE
Addition of Automatic Heat and Smoke Vent

### DIFF
--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -1,7 +1,8 @@
 asset_type,abbreviation,ifc_class,ifc_type,haystack_parent,haystack_child,brick_parent,brick_child
 actuator,ATR,IfcActuator,NOTDEFINED,Actuator,actuator,,
 air handling unit,AHU,IfcUnitaryEquipment,AIRHANDLER,Air Handling Unit,"ahu, airHandlingEquip","Air Handler Unit, AHU",
-automatic transfer switch,ATS,IfcProtectiveDevice ,NOTDEFINED,,,,
+automatic transfer switch,ATS,IfcProtectiveDevice,NOTDEFINED,,,,
+automatic heat and smoke vent,AHSV,IfcUnitaryEquipment,NOTDEFINED,,,,
 boiler,BLR,ifcBoiler,NOTDEFINED,Boiler,boiler,Boiler,Boiler
 break glass unit,BGU,,,,,,
 air conditioning unit,ACU,IfcUnitaryEquipment,AIRCONDITIONINGUNIT,,,,


### PR DESCRIPTION
Suggest addition as per github issue below. @pisuke @richardkreid - Agree?

Automatic heat and smoke vents are available commercially in two general categories. Concerning the scope of this effort, the mechanically opened vent, powered by springs, pneumatic actuator, or electric motors are of interest. The open/close state data point needs to attributed.

Should there be an abbreviation for automatic vents?

Note: we are aware of regional variations ie smoke extractor in Berlin.

https://github.com/theodi/BDNS/issues/26#issue-622619872