### PR TITLE
Edit air terminal box (VAV) types

### DIFF
--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -8,8 +8,7 @@ air conditioning unit - computer room AC unit,CRAC,IfcUnitaryEquipment,AIRCONDIT
 air conditioning unit - direct expansion cooling unit,DX,IfcUnitaryEquipment,SPLITSYSTEM
 air terminal box - constant air volume box,CAV,IfcAirTerminalBox,CONSTANTFLOW
 air terminal box - variable air volume box,VAV,IfcAirTerminalBox,NOTDEFINED
-air terminal box - variable volume and temperature box,VVTB,IfcAirTerminalBox,NOTDEFINED
-air terminal box - variable volume terminal unit,VVT,IfcAirTerminalBox,NOTDEFINED
+air terminal box - fan powered variable air volume box,VAVFP,IfcAirTerminalBox,NOTDEFINED
 antenna,ANT,IfcCommunicationsAppliance,ANTENNA
 antenna - wi-fi antenna,WANT,IfcCommunicationsAppliance,ANTENNA
 architecture - room,ROOM,IfcSpace,INTERNAL

--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -7,8 +7,8 @@ air conditioning unit,ACU,IfcUnitaryEquipment,AIRCONDITIONINGUNIT
 air conditioning unit - computer room AC unit,CRAC,IfcUnitaryEquipment,AIRCONDITIONINGUNIT
 air conditioning unit - direct expansion cooling unit,DX,IfcUnitaryEquipment,SPLITSYSTEM
 air terminal box - constant air volume box,CAV,IfcAirTerminalBox,CONSTANTFLOW
+air terminal box - fan powered variable air volume box,FPVAV,IfcAirTerminalBox,NOTDEFINED
 air terminal box - variable air volume box,VAV,IfcAirTerminalBox,NOTDEFINED
-air terminal box - fan powered variable air volume box,VAVFP,IfcAirTerminalBox,NOTDEFINED
 antenna,ANT,IfcCommunicationsAppliance,ANTENNA
 antenna - wi-fi antenna,WANT,IfcCommunicationsAppliance,ANTENNA
 architecture - room,ROOM,IfcSpace,INTERNAL


### PR DESCRIPTION
1. Add an entry for fan-powered VAVs `FPVAV`. These are common in North America and it is industry standard to identify them separately from "regular" VAVs. They are usually considered as a separate equipment type because they contain additional hardware and control schemes that differ from "regular" VAVs.
2. Remove entry for variable volume and temperature box `VVTB`. It is unclear where this acronym came from, and it appears to not be commonly (or ever) used. It appears to define a device that is very similar if not identical to a "regular" VAV. If it is intended to be specific to a VAV with integral reheat coil, then we need to have more discussion.
3. Remove entry for variable volume terminal unit, `VVT`. It is unclear where this acronym came from, and it appears to not be commonly (or ever) used. It appears to define a device that is very similar if not identical to a "regular" VAV.