### PR TITLE
Add package unit type to register and more

### DIFF
--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -14,7 +14,6 @@ air handling unit - air handling unit,AHU,HVAC/AHU,IfcUnitaryEquipment,AIRHANDLE
 air handling unit - dedicated outside air system unit,DOAS,HVAC/DOAS,IfcUnitaryEquipment,AIRHANDLER
 air handling unit - heat recovery unit,HRU,HVAC/AHU,IfcAirToAirHeatRecovery,NOTDEFINED
 air handling unit - make-up air handler,MAU,HVAC/MAU,IfcUnitaryEquipment,AIRHANDLER
-air handling unit - roof top unit,RTU,HVAC/AHU,IfcUnitaryEquipment,ROOFTOPUNIT
 air conditioning unit,ACU,HVAC/AHU,IfcUnitaryEquipment,AIRCONDITIONINGUNIT
 air conditioning unit - computer room AC unit,CRAC,HVAC/AHU,IfcUnitaryEquipment,AIRCONDITIONINGUNIT
 air conditioning unit - direct expansion cooling unit,DX,HVAC/AHU,IfcUnitaryEquipment,SPLITSYSTEM

--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -360,6 +360,10 @@ outlet - floor duplex outlet,FLRDX,,IfcOutlet,DATAOUTLET
 outlet - floor quad outlet,FLRQD,,IfcOutlet,DATAOUTLET
 outlet - linear electric receptacle,LER,,IfcOutlet,NOTDEFINED
 outlet - raised floor box,FLRB,,IfcOutlet,NOTDEFINED
+package unit - air conditioning package unit,ACPU,HVAC/PU,IfcUnitaryEquipment,PACKAGE 
+package unit - gas/electric package unit, GEPU,HVAC/PU,IfcUnitaryEquipment,PACKAGE 
+package unit - heat pump package unit, HPPU,HVAC/PU,IfcUnitaryEquipment,PACKAGE 
+package unit - dual-fuel package unit, DFPU,HVAC/PU,IfcUnitaryEquipment,PACKAGE 
 panel - alarm panel,AP,,IfcUnitaryControlElement,ALARMPANEL
 panel - chemical treatment control panel,CTCP,,IfcUnitaryControlElement,NOTDEFINED
 panel - control panel,CTRP,,IfcUnitaryControlElement,CONTROLPANEL

--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -64,7 +64,7 @@ cleaning - standalone laundry tumble dryer,TDY,,IfcElectricAppliance,TUMBLEDRYER
 cleaning - floor cleaner scrubber dryer,FCSD,,IfcElectricAppliance,NOTDEFINED
 coil,COIL,,IfcCoil,NOTDEFINED
 coil - cooling coil,CC,,IfcCoil,WATERCOOLINGCOIL
-coil - dx reversible coil,DXC,,IfcCoil,NOTDEFINED
+coil - dx reversible coil,DXRC,,IfcCoil,NOTDEFINED
 coil - frost or preheat coil,PHC,,IfcCoil,NOTDEFINED
 coil - heating coil,HC,,IfcCoil,WATERHEATINGCOIL
 coil - reheat coil,RHC,,IfcCoil,NOTDEFINED


### PR DESCRIPTION
- remove RTU from register
- improve asset abbreviation to imply DX coil is reversible
- add package unit types, which serve as a replacement for the RTU