### PR TITLE
updated the default paths such that both of the scripts can be run from the root repo

### DIFF
--- a/tools/check-duplicates.py
+++ b/tools/check-duplicates.py
@@ -38,7 +38,7 @@ def check_duplicates(filename):
 def main():
     show_title()
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i","--input", default="abbreviations.csv", help="Input CSV file to check for duplicates")
+    parser.add_argument("-i","--input", default="BDNS_Abbreviations_Register.csv", help="Input CSV file to check for duplicates")
     args = parser.parse_args()
     if exists(args.input):
         check_duplicates(args.input)

--- a/tools/sort.py
+++ b/tools/sort.py
@@ -64,7 +64,7 @@ def main():
     parser.add_argument(
         "-i",
         "--input",
-        default="../BDNS_Abbreviations_Register.csv",
+        default="BDNS_Abbreviations_Register.csv",
         help="Input CSV file to check sorted",
     )
     parser.add_argument(


### PR DESCRIPTION
updated the default filepaths of the `sort.py` and `check-duplicates.py` scripts point at `BDNS_Abbreviations_Register.csv` file when the scripts are run from the repo root. 

this simplifies the use of the scripts as you don't need to explicitly give the filepath.

i.e. 

```console
python tools/check-duplicates.py
python tools/sort.py
```

this doesn't affect the GH actions which explicity give the filepath.