### PR TITLE
✨ Add dirt separator - DTS

### DIFF
--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -279,6 +279,7 @@ filter - cooling tower sand filter,CTSFLT,,IfcFilter,NOTDEFINED
 filter - cooling tower separator,CTSEP,,IfcFilter,NOTDEFINED
 filter - cooling tower separator / sand separator,CTSSEP,,IfcFilter,NOTDEFINED
 filter - degasser filter,DGA,,IfcFilter,NOTDEFINED
+filter - dirt separator,DTS,,IfcFilter,NOTDEFINED
 filter - exhaust dry scrubber unit,DSU,,IfcFilter,NOTDEFINED
 filter - panel filter,PFLT,,IfcFilter,NOTDEFINED
 filter - pollution control unit,PCU,,IfcFilter,AIRPARTICLEFILTER


### PR DESCRIPTION
`air separator` and `air and dirt separator` already exist as abbreviations. I think it would be good to add `dirt separator` as it is common to use them in closed loop heating and cooling systems when deaeration is done separately either by an air separator or vacuum degasser.