### PR TITLE
addition of EBM - electric branch meter

### DIFF
--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -437,6 +437,7 @@ lighting - group,LGRP,LIGHTING/LGRP,IfcGroup,NOTDEFINED,1
 lighting - track - electric track for lights,TR,LIGHTING/LT,IfcCableSegment,NOTDEFINED,0
 location services - beacon,LBCN,,IfcCommunicationsAppliance,NOTDEFINED,1
 meter,MTR,METERS/MTR,IfcFlowMeter,NOTDEFINED,1
+meter - electric branch meter,EBM,METERS/MTR,IfcFlowMeter,NOTDEFINED,1
 meter - electric meter,EM,METERS/EM,IfcFlowMeter,ENERGYMETER,1
 meter - flow meter,FM,METERS/FM,IfcFlowMeter,NOTDEFINED,1
 meter - gas meter,GM,METERS/GM,IfcFlowMeter,GASMETER,1


### PR DESCRIPTION
Addition of the electric branch meter with the EBM abbreviation, as discussed in issue #241 