### PR TITLE
add EWH, GWH

### DIFF
--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -681,6 +681,8 @@ waste management - wet waste grinder,WSTWG,,IfcElectricAppliance,NOTDEFINED,0
 waste terminal - area drain,AD,,IfcWasteTerminal,NOTDEFINED,0
 water heater - domestic electric water heater,DEWH,HVAC/HWS,IfcElectricAppliance,FREESTANDINGWATERHEATER,0
 water heater - domestic gas water heater,DGWH,HVAC/HWS,IfcBoiler,WATER,0
+water heater - electric water heater,EWH,HVAC/HWS,IfcElectricAppliance,FREESTANDINGWATERHEATER,0
+water heater - gas water heater,GWH,HVAC/HWS,IfcBoiler,WATER,0
 water heater - instantaneous water heater,IWH,HVAC/HWS,IfcElectricAppliance,NOTDEFINED,0
 water heater - solar water heating panel,SWHP,,IfcSolarDevice,SOLARCOLLECTOR,0
 water treatment - chemical dosage unit,CHDU,,IfcDistributionSystem,CHEMICAL,1


### PR DESCRIPTION
electric water heater, gas water heater. note that DEWH, and DGWH exist where the D stands for "Domestic" (i.e. domestic water). Given that a water heater could be used for different water types (e.g. Cat 5, distilled, etc.) suggest that abbreviations shouldn't explitly require it.

revisit in the future whether DEWH and DGWH should be archived or deleted.