### PR TITLE
289-vavs-cavs

### DIFF
--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -22,6 +22,8 @@ air handling unit - make-up air handler,MAU,HVAC/MAU,IfcUnitaryEquipment,AIRHAND
 air handling unit - roof top unit,RTU,HVAC/AHU,IfcUnitaryEquipment,ROOFTOPUNIT,1
 air terminal - generic,AT,,IfcAirTerminal,NOTDEFINED,1
 air terminal box - constant air volume box,CAV,,IfcAirTerminalBox,CONSTANTFLOW,1
+air terminal box - constant air volume box - extract,CAVE,,IfcAirTerminalBox,CONSTANTFLOW,1
+air terminal box - constant air volume box - supply,CAVS,,IfcAirTerminalBox,CONSTANTFLOW,1
 air terminal box - fan powered box,FPB,,IfcAirTerminalBox,NOTDEFINED,1
 air terminal box - under floor variable air volume box,UFT,HVAC/VAV,IfcAirTerminalBox,NOTDEFINED,1
 air terminal box - variable air volume box,VAV,HVAC/VAV,IfcAirTerminalBox,NOTDEFINED,1

--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -25,6 +25,8 @@ air terminal box - constant air volume box,CAV,,IfcAirTerminalBox,CONSTANTFLOW,1
 air terminal box - fan powered box,FPB,,IfcAirTerminalBox,NOTDEFINED,1
 air terminal box - under floor variable air volume box,UFT,HVAC/VAV,IfcAirTerminalBox,NOTDEFINED,1
 air terminal box - variable air volume box,VAV,HVAC/VAV,IfcAirTerminalBox,NOTDEFINED,1
+air terminal box - variable air volume box - extract,VAVE,HVAC/VAV,IfcAirTerminalBox,NOTDEFINED,1
+air terminal box - variable air volume box - supply,VAVS,HVAC/VAV,IfcAirTerminalBox,NOTDEFINED,1
 air terminal box - variable volume and temperature box,VVTB,,IfcAirTerminalBox,NOTDEFINED,1
 air terminal box - variable volume terminal unit,VVT,,IfcAirTerminalBox,NOTDEFINED,1
 alarm - disabled alarm,DA,,IfcAlarm,MANUALPULLBOX,1

--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -23,7 +23,11 @@ air handling unit - roof top unit,RTU,HVAC/AHU,IfcUnitaryEquipment,ROOFTOPUNIT,1
 air terminal - generic,AT,,IfcAirTerminal,NOTDEFINED,1
 air terminal box - constant air volume box,CAV,,IfcAirTerminalBox,CONSTANTFLOW,1
 air terminal box - constant air volume box - extract,CAVE,,IfcAirTerminalBox,CONSTANTFLOW,1
+air terminal box - constant air volume box - extract - fixed,CAVEF,,IfcAirTerminalBox,CONSTANTFLOW,1
+air terminal box - constant air volume box - extract - mechanically actuated,CAVEM,,IfcAirTerminalBox,CONSTANTFLOW,1
 air terminal box - constant air volume box - supply,CAVS,,IfcAirTerminalBox,CONSTANTFLOW,1
+air terminal box - constant air volume box - supply - fixed,CAVSF,,IfcAirTerminalBox,CONSTANTFLOW,1
+air terminal box - constant air volume box - supply - mechanically actuated,CAVSM,,IfcAirTerminalBox,CONSTANTFLOW,1
 air terminal box - fan powered box,FPB,,IfcAirTerminalBox,NOTDEFINED,1
 air terminal box - under floor variable air volume box,UFT,HVAC/VAV,IfcAirTerminalBox,NOTDEFINED,1
 air terminal box - variable air volume box,VAV,HVAC/VAV,IfcAirTerminalBox,NOTDEFINED,1

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ name: bdns
 # --------------------------------- 
 # requirements for building docs
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python>=3.8


### PR DESCRIPTION
closes #289

for completeness I added CAVS and CAVE (i.e. not specifying if mechanically actuated or fixed). 

cautionary note - I think we need to be a little careful of this type of thing generally as CAVS and CAVE are basically the same object in a different system configuration. This logic applied generally could lead to many new additions. That said I do acknowledge this can improve legibility within design information