### PR TITLE
fix CI again... 

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
       - name: GitHub Tag Name example
         run: |
           echo "Status: *release* $GITHUB_REF_NAME" > release.md

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,7 +14,6 @@ jobs:
         run: |
           echo "Status: *release* $GITHUB_REF_NAME" > release.md
           
-      - name: setup-micromamba
       - uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment.yml


### PR DESCRIPTION
sorry, I got confused while I was testing before and thought I was looking at freshly built docs but was actually looking at an old one... 

this PR should now work... 
it was built on tag 1.4.0rc6 from my fork, and my forks docs now match:
https://jgunstone.github.io/BDNS/

and here is the successfully run log of the GH action:
https://github.com/jgunstone/BDNS/actions/runs/13157508289/job/36717934641

