### PR TITLE
➕CSO - Commando Socket Outlet

### DIFF
--- a/BDNS_Abbreviations_Register.csv
+++ b/BDNS_Abbreviations_Register.csv
@@ -494,6 +494,7 @@ natural air ventilator,AVR,,ifcStackTerminal,NOTDEFINED,1
 oil interceptor,OI,,IfcInterceptor,OIL,0
 outlet,OUT,,IfcOutlet,NOTDEFINED,0
 outlet - ceiling duplex,CGDXO,,IfcOutlet,POWEROUTLET,0
+outlet - commando socket outlet,CSO,,IfcOutlet,POWEROUTLET,0
 outlet - connection unit switched fused,CUSF,,IfcOutlet,POWEROUTLET,0
 outlet - connection unit unswitched fused,CUUF,,IfcOutlet,POWEROUTLET,0
 outlet - controlled duplex,CNDO,,IfcOutlet,DATAOUTLET,0


### PR DESCRIPTION
closes #330

this was discussed last week and Commando socket is an MK device so should be avoided / isn't appropriate for an international audience. 

propose instead something pertaining to industrial socket outlet... though `ISO` should probs also be avoided as this is used by the standards body and is confusing compared to `EISO` for electrical isolator. 